### PR TITLE
ci(github): 为工作流添加必要的权限配置

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -20,6 +20,9 @@ jobs:
   build:
     name: Build Firmware
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # 读取代码
+      actions: read   # 读取 actions
     
     steps:
     # 检出代码
@@ -126,6 +129,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write  # 创建 release 需要写权限
+      actions: read    # 下载 artifacts
     
     steps:
     # 检出代码
@@ -219,6 +225,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     if: always()
+    permissions:
+      contents: read  # 只需要读权限
     
     steps:
     - name: Build status notification

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
   lint:
     name: Code Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read  # 只需要读取代码
     
     steps:
     - name: Checkout code
@@ -48,6 +50,8 @@ jobs:
     name: Build Check
     runs-on: ubuntu-latest
     needs: lint
+    permissions:
+      contents: read  # 只需要读取代码
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
为 CI 和发布工作流中的 jobs 添加适当的 permissions 配置，确保各步骤具有所需的最小权限